### PR TITLE
Add Syfony 3 and 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-  - 5.3.3
-  - 5.3
-  - 5.4
-  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
 
 before_script:
     - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev install

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,5 +3,5 @@ parameters:
 
 services:
     ee.dataexporter:
-        class: %ee.dataexporter.class%
+        class: "%ee.dataexporter.class%"
         public: true

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "~2.1",
-        "symfony/http-foundation": "~2.1",
-        "symfony/property-access": "~2.1"
+        "symfony/framework-bundle": ">=2.1,<5",
+        "symfony/http-foundation": ">=2.1,<5",
+        "symfony/property-access": ">=2.1,<5"
     },
     "require-dev": {
         "symfony/yaml": "~2.1"


### PR DESCRIPTION
Some simple compatibility changes have been added to the project:

- Allow newer Symfony versions by allowing them in the composer.json dependency version requirements.
- Did a little deprecation warning fix
- Changed the travis build coverage slightly, adding builds for modern versions of PHP

My suggestion is to remove the builds for legacy PHP versions, but that's up to you guys :).

:warning: Disclaimer, I currently have no Symfony 4 project to test these changes on. But I've testsed quite extensively with a Symfony 3.4 project.