### PR TITLE
[ASAP] Backward incompatible changes fix

### DIFF
--- a/Service/DataExporter.php
+++ b/Service/DataExporter.php
@@ -200,7 +200,7 @@ class DataExporter
                 } else {
                     $obj = new $hooks[$column][0];
                 }
-                $data = $obj->$hooks[$column][1]($data);
+                $data = $obj->{$hooks[$column][1]}($data);
             }
         }
 


### PR DESCRIPTION
### Fixed
Fix callback invocation according to https://www.php.net/manual/en/migration70.incompatible.php
### Issues
When user has PHP7.4 and sets a hook like this
```lang-php
$exporter->addHook(['className', 'methodName'], 'fieldname');
```
It causes an error:
`Uncaught PHP Exception Error: "Function name must be a string" at /var/www/html/vendor/ee/dataexporter-bundle/EE/DataExporterBundle/Service/DataExporter.php line 236 {"exception":"[object] (Error(code: 0): Function name must be a string at /var/www/html/vendor/ee/dataexporter-bundle/EE/DataExporterBundle/Service/DataExporter.php:236)"} []`